### PR TITLE
Upgrade to Java 16 for Minecraft 1.17 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
-FROM ubuntu:xenial
+FROM ubuntu:impish
 MAINTAINER Yuji ODA
 ENV MINEOS_VERSION 1.1.7
+ENV DEBIAN_FRONTEND=noninteractive
 
 # Installing Dependencies
 RUN apt-get update; \
-    apt-get -y install git rdiff-backup screen build-essential openjdk-8-jre-headless uuid pwgen curl rsync
+    apt-get -y install git rdiff-backup screen build-essential openjdk-16-jre-headless uuid pwgen curl rsync
 
 # Installing node 4.x
 RUN curl -sL https://deb.nodesource.com/setup_4.x | bash -; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,29 @@
-FROM ubuntu:impish
+# FROM ubuntu:impish
+FROM ubuntu:focal
 MAINTAINER Yuji ODA
-ENV MINEOS_VERSION 1.1.7
+
+ENV MINEOS_VERSION 1.3.0
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Installing Dependencies
 RUN apt-get update; \
-    apt-get -y install git rdiff-backup screen build-essential openjdk-16-jre-headless uuid pwgen curl rsync
-
-# Installing node 4.x
-RUN curl -sL https://deb.nodesource.com/setup_4.x | bash -; \
-    apt-get -y install nodejs
+    apt-get -y install git rdiff-backup screen build-essential gcc g++ make openjdk-16-jre-headless uuid pwgen curl rsync
 
 # Installing MineOS scripts
 RUN mkdir -p /usr/games/minecraft /var/games/minecraft; \
-    curl -L https://github.com/hexparrot/mineos-node/archive/v${MINEOS_VERSION}.tar.gz | tar xz -C /usr/games/minecraft --strip=1; \
+    curl -L https://github.com/hexparrot/mineos-node/archive/refs/tags/${MINEOS_VERSION}.tar.gz | tar xz -C /usr/games/minecraft --strip=1; \
     cd /usr/games/minecraft; \
-    npm install; \
     chmod +x service.js mineos_console.js generate-sslcert.sh webui.js; \
     ln -s /usr/games/minecraft/mineos_console.js /usr/local/bin/mineos
+
+WORKDIR /usr/games/minecraft
+
+# install node and node modules
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash; \
+    export NVM_DIR="$HOME/.nvm"; \
+    [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"; \
+    nvm install 8.17.0; \
+    npm install
 
 # Customize server settings
 ADD mineos.conf /etc/mineos.conf
@@ -35,7 +41,6 @@ RUN apt-get -y remove build-essential; \
     apt-get clean
 
 VOLUME /var/games/minecraft
-WORKDIR /usr/games/minecraft
 EXPOSE 8443 25565 25566 25567 25568 25569 25570
 
 CMD ["./start.sh"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # minecraft-mineos
 
-Dockerfile for creating Mine OS server image with Java 8.
+Dockerfile for creating Mine OS server image with Java 16.
 
 [Mine OS - easy minecraft hosting solution](http://minecraft.codeemo.com/)
 

--- a/start.sh
+++ b/start.sh
@@ -50,6 +50,6 @@ _trap() {
 trap '_trap' 15
 
 # Starting mineos
-/usr/bin/node webui.js & PID=$!
+/root/.nvm/versions/node/v8.17.0/bin/node webui.js & PID=$!
 
 wait $PID


### PR DESCRIPTION
I had to upgrade to a more recent release of Ubuntu to get openjdk-16. I'm not super familiar with apt, but from what I could tell, the system repos for Ubuntu Focal have node 10 in them, so the node 8 from NodeSource was being ignored. I couldn't figure out how to work around that, so I switched to using nvm to install node. I also upgraded to the latest mineos scripts.

For other users of this image, my update is published on docker hub under `chuckdries/minecraft-mineos`. It's a drop-in replacement you can start using right away.